### PR TITLE
Update README for Ubuntu python3-setproctitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ $ sudo pacman -S python-gobject python-yaml python-setuptools python-lxml python
 #### PREPARE UBUNTU 18.04 LTS
 
 ``` bash
-$ sudo apt-get install python3-gi python3-setuptools python3-lxml gir1.2-gtk-3.0 gir1.2-gstreamer-1.0 gstreamer1.0-gtk3 mediainfo ffmpeg
+$ sudo apt-get install python3-gi python3-setuptools python3-setproctitle python3-lxml gir1.2-gtk-3.0 gir1.2-gstreamer-1.0 gstreamer1.0-gtk3 mediainfo ffmpeg
 ```
 
 ### ARE WE THERE YET?


### PR DESCRIPTION
Launching this from Ubuntu caused:

```
~/.local/lib/python3.6/site-packages/gpt python3 run.py                 
Traceback (most recent call last):
  File "run.py", line 5, in <module>
    import modules
  File "/home/kevin/.local/lib/python3.6/site-packages/gpt/modules.py", line 24, in <module>
    import setproctitle
ModuleNotFoundError: No module named 'setproctitle'
```

Adding the missing dependency `python3-setproctitle` to Ubuntu README.